### PR TITLE
Player armies can now only move once unless they move into another ar…

### DIFF
--- a/Hex.js
+++ b/Hex.js
@@ -19,6 +19,7 @@ class Hex {
         this.#hexTerrain = hexTerrainType.PLAINS;
         this.#hexImprovement = hexImprovementType.NONE;
         this.soldierCount = 0;
+        this.hasMovedThisTurn = false;  // Add this new property
     }
 
     get active(){
@@ -73,6 +74,11 @@ class Hex {
     // String representation of the Hex
     toString() {
         return `q:${this.q}, r:${this.r}, s:${this.s}`;
+    }
+
+    // Add a method to reset the movement flag
+    resetMovement() {
+        this.hasMovedThisTurn = false;
     }
 }
 

--- a/HexWorld.js
+++ b/HexWorld.js
@@ -104,13 +104,26 @@ class HexWorld {
         attackingHex.soldierCount = 0;
       } else if (attackingHex.hexImprovement === hexImprovementType.HOME) {
         // If they're moving from storage make sure we pull it from there.
+        let initialDefendingSoldierCount = defendingHex.soldierCount;
         defendingHex.soldierCount += attackingHex.playerOwner.storage;
         attackingHex.playerOwner.zeroOutStorage();
+
+        if (initialDefendingSoldierCount <= 0) {
+            // If there aren't any soldiers in the hex we're moving to then we need to mark the hex as moved.
+            defendingHex.hasMovedThisTurn = true;
+        }
       } else {
         // They're moving from one regular hex to another. Combine soldier counts and clear out any improvements.
+        let initialDefendingSoldierCount = defendingHex.soldierCount;
         defendingHex.soldierCount += attackingHex.soldierCount;
         defendingHex.hexImprovement = hexImprovementType.NONE;
         attackingHex.soldierCount = 0;
+
+        if (initialDefendingSoldierCount <= 0) {
+            // If there aren't any soldiers in the hex we're moving to then we need to mark the hex as moved.
+            defendingHex.hasMovedThisTurn = true;
+        }
+        
       }
     } else {
       // They are attacking a hexagon they do not own.
@@ -172,6 +185,7 @@ class HexWorld {
           }
           defendingHex.soldierCount = soldiersLeftOver;
           defendingHex.playerOwner = attackingHex.playerOwner;
+          defendingHex.hasMovedThisTurn = true;
         } else if (soldiersLeftOver < 0) {
           // Defending won
           if (attackingHex.hexImprovement === hexImprovementType.HOME) {
@@ -227,6 +241,17 @@ class HexWorld {
         }
         return adjacentHexes;
     }
+
+  // Add a new method to reset all hexes' movement for a specific player
+  resetMovementForPlayer(player) {
+    this.#worldMap.forEach(row => {
+      row.forEach(hex => {
+        if (hex.playerOwner === player) {
+          hex.resetMovement();
+        }
+      });
+    });
+  }
 }
 
 export default HexWorld;

--- a/index.js
+++ b/index.js
@@ -96,7 +96,8 @@ function addEventListenersToHexes() {
                 // We are in teh attacking phase.
                 let activeHex = gameState.getActiveHex();
                 if (activeHex == null) {
-                    if (clickedHex.playerOwner == localCP) {
+                    // Only allow selecting hexes that haven't moved this turn
+                    if (clickedHex.playerOwner == localCP && !clickedHex.hasMovedThisTurn) {
                         gameState.setActiveHex(clickedHex);
                     }
                 } else {
@@ -191,11 +192,20 @@ function calculateCurrentPlayerStorage() {
 
 // End the current players turn and update a bunch of stuff.
 function endCurrentPlayerTurn() {
+    // Unset any selected hex before changing turns
+    gameState.unsetActiveHex();
+
     if (gameState.checkForGameOver(theWorld)) {
         displayGameOver();
     } else {
         console.log(`Ending player ${gameState.getCurrentPlayer().name} turn`);
         gameState.increaseCurrentTurn();
+        
+        // If we're entering the attacking phase for a player, reset their movement
+        if (gameState.isAttackingPhase()) {
+            theWorld.resetMovementForPlayer(gameState.getCurrentPlayer());
+        }
+        
         displayCurrentPlayer();
         displayCurrentTurn();
         displayCurrentRound();


### PR DESCRIPTION
closes #24 
Player armies will only be able to move one time unless they joined with one of their own armies that hasn't already moved. This way players can quickly mass armies and move them a long ways.