### PR TITLE
Select Random when all else is equal

### DIFF
--- a/modules/ComputerPlayerAI.js
+++ b/modules/ComputerPlayerAI.js
@@ -88,9 +88,10 @@ export class ComputerPlayerAI {
             );
 
             if (strategicEmptyHexes.length > 0) {
-                return strategicEmptyHexes[0];
+                return strategicEmptyHexes[Math.floor(Math.random() * strategicEmptyHexes.length)];
             }
-            return emptyHexes[0];
+            // Choose a random empty hex instead of always taking the first one
+            return emptyHexes[Math.floor(Math.random() * emptyHexes.length)];
         }
 
         // Last priority: Combine forces with friendly hexes


### PR DESCRIPTION
closes #48 
Instead of always choosing the top right and working around clockwise when all else is equal select a random hex.